### PR TITLE
Fix enums & empty /orders POST body handling

### DIFF
--- a/src/main/kotlin/com/itmo/microservices/demo/order/impl/entities/OrderEntity.kt
+++ b/src/main/kotlin/com/itmo/microservices/demo/order/impl/entities/OrderEntity.kt
@@ -35,7 +35,12 @@ class OrderEntity {
     constructor()
 
     constructor(
-        id: UUID?,
+            userId: UUID?,
+    ) {
+        this.userId = userId
+    }
+
+    constructor(
         userId: UUID?,
         timeCreated: LocalDateTime,
         status: OrderStatus,
@@ -43,7 +48,6 @@ class OrderEntity {
         deliveryDuration: Int?,
         paymentHistory: List<UserAccountFinancialLogRecord>?
     ) {
-        this.id = id
         this.userId = userId
         this.timeCreated = timeCreated
         this.status = status

--- a/src/main/kotlin/com/itmo/microservices/demo/order/impl/entities/OrderEntity.kt
+++ b/src/main/kotlin/com/itmo/microservices/demo/order/impl/entities/OrderEntity.kt
@@ -21,6 +21,7 @@ class OrderEntity {
 
     var timeCreated: LocalDateTime = LocalDateTime.now()
 
+    @Enumerated(EnumType.STRING)
     var status: OrderStatus = OrderStatus.COLLECTING
 
     var deliveryDuration: Int? = 0

--- a/src/main/kotlin/com/itmo/microservices/demo/order/impl/service/DefaultOrderService.kt
+++ b/src/main/kotlin/com/itmo/microservices/demo/order/impl/service/DefaultOrderService.kt
@@ -10,6 +10,8 @@ import com.itmo.microservices.demo.order.impl.entities.OrderEntity
 import com.itmo.microservices.demo.order.impl.repository.OrderItemRepository
 import com.itmo.microservices.demo.order.impl.util.toModel
 import com.itmo.microservices.demo.tasks.impl.repository.OrderRepository
+import com.itmo.microservices.demo.users.api.service.UserService
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Service
 import org.webjars.NotFoundException
@@ -20,7 +22,8 @@ import java.util.*
 class DefaultOrderService(
     private val orderRepository: OrderRepository,
     private val orderItemRepository: OrderItemRepository,
-    private val itemService: WarehouseService
+    private val itemService: WarehouseService,
+    private val userService: UserService
     ): OrderService {
 
     override fun getOrder(order_id: UUID): OrderDto {
@@ -33,7 +36,8 @@ class DefaultOrderService(
 
     override fun createOrder(user: UserDetails): OrderDto {
         //create base order
-        val orderEntity = OrderEntity()
+        val currentUser = SecurityContextHolder.getContext().authentication.principal as UserDetails
+        val orderEntity = OrderEntity(userService.getUser(currentUser.username)?.id)
         //save base order, convert it to dto and return it
         return orderRepository.save(orderEntity).toModel(orderItemRepository)
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: p03
   datasource:
-    url: jdbc:postgresql://postgresql:5432/p03
+    url: jdbc:postgresql://postgresql:5432/p03?stringtype=unspecified
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver

--- a/src/test/java/com/itmo/microservices/demo/order/impl/service/GetOrderTest.java
+++ b/src/test/java/com/itmo/microservices/demo/order/impl/service/GetOrderTest.java
@@ -8,6 +8,7 @@ import com.itmo.microservices.demo.order.impl.entities.OrderItemEntity;
 import com.itmo.microservices.demo.order.impl.repository.OrderItemRepository;
 import com.itmo.microservices.demo.payment.impl.model.UserAccountFinancialLogRecord;
 import com.itmo.microservices.demo.tasks.impl.repository.OrderRepository;
+import com.itmo.microservices.demo.users.impl.service.DefaultUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,6 @@ public class GetOrderTest {
 
         orderEntity = new OrderEntity(
                 UUID.randomUUID(),
-                UUID.randomUUID(),
                 LocalDateTime.now(),
                 OrderStatus.PAID,
                 items,
@@ -47,7 +47,7 @@ public class GetOrderTest {
 
         orderItemRepository = mock(OrderItemRepository.class);
 
-        orderService = new DefaultOrderService(orderRepository, orderItemRepository, mock(DefaultWarehouseService.class));
+        orderService = new DefaultOrderService(orderRepository, orderItemRepository, mock(DefaultWarehouseService.class), mock(DefaultUserService.class));
     }
 
     @Test

--- a/src/test/java/com/itmo/microservices/demo/order/service/AddItemToTheCartTest.java
+++ b/src/test/java/com/itmo/microservices/demo/order/service/AddItemToTheCartTest.java
@@ -10,6 +10,7 @@ import com.itmo.microservices.demo.order.impl.entities.OrderItemEntity;
 import com.itmo.microservices.demo.order.impl.repository.OrderItemRepository;
 import com.itmo.microservices.demo.order.impl.service.DefaultOrderService;
 import com.itmo.microservices.demo.tasks.impl.repository.OrderRepository;
+import com.itmo.microservices.demo.users.impl.service.DefaultUserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
@@ -45,13 +46,12 @@ public class AddItemToTheCartTest {
 
         var orderRepository = mock(OrderRepository.class);
         orderEntityUUID = UUID.randomUUID();
-        var orderEntity = new OrderEntity(orderEntityUUID, UUID.randomUUID(), LocalDateTime.now(), OrderStatus.COLLECTING, null, 5, null);
-        when(orderRepository.getById(orderEntityUUID)).thenReturn(orderEntity);
-
+        var orderEntity = new OrderEntity(UUID.randomUUID(), LocalDateTime.now(), OrderStatus.COLLECTING, null, 5, null);
+        when(orderRepository.getById(orderEntity.getId())).thenReturn(orderEntity);
 
         var itemService = new DefaultWarehouseService(itemRepository, mock(EventBus.class));
         orderItemRepository = mock(OrderItemRepository.class);
-        orderService = new DefaultOrderService(orderRepository, orderItemRepository, itemService);
+        orderService = new DefaultOrderService(orderRepository, orderItemRepository, itemService, mock(DefaultUserService.class));
     }
 
     @Test

--- a/src/test/java/com/itmo/microservices/demo/order/service/OrderServiceTests.java
+++ b/src/test/java/com/itmo/microservices/demo/order/service/OrderServiceTests.java
@@ -8,6 +8,7 @@ import com.itmo.microservices.demo.order.impl.entities.OrderEntity;
 import com.itmo.microservices.demo.order.impl.repository.OrderItemRepository;
 import com.itmo.microservices.demo.order.impl.service.DefaultOrderService;
 import com.itmo.microservices.demo.tasks.impl.repository.OrderRepository;
+import com.itmo.microservices.demo.users.impl.service.DefaultUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,6 @@ public class OrderServiceTests {
 	public void init() {
 		orderEntity = new OrderEntity(
 				UUID.randomUUID(),
-				UUID.randomUUID(),
 				LocalDateTime.now(),
 				OrderStatus.COLLECTING,
 				new ArrayList<>(),
@@ -50,7 +50,7 @@ public class OrderServiceTests {
 
 		orderItemRepository = mock(OrderItemRepository.class);
 
-		orderService = new DefaultOrderService(orderRepository, orderItemRepository, mock(DefaultWarehouseService.class));
+		orderService = new DefaultOrderService(orderRepository, orderItemRepository, mock(DefaultWarehouseService.class), mock(DefaultUserService.class));
 	}
 
 	@Test


### PR DESCRIPTION
- Stop relying on UserDetails when creating an order (use authentication data instead)
- Change enum handling in PostgreSQL (use strings for them)